### PR TITLE
Swapped out 2x multiplier checkbox for intensity slider

### DIFF
--- a/Assets/SpriteLightKit/SpriteLightKitImageEffect.cs
+++ b/Assets/SpriteLightKit/SpriteLightKitImageEffect.cs
@@ -9,7 +9,7 @@ namespace Prime31
 	{
 		public Shader shader;
 		public RenderTexture spriteLightRT;
-		public bool use2xMultiplicationBlending = false;
+		[Range(0.0f, 2.0f)] public float intensity = 1.0f;
 		Material _material;
 
 
@@ -45,7 +45,7 @@ namespace Prime31
 				return;
 		
 			material.SetTexture( "_LightsTex", spriteLightRT );
-			material.SetFloat( "_MultiplicativeFactor", use2xMultiplicationBlending ? 2f : 1f );
+			material.SetFloat( "_MultiplicativeFactor", intensity );
 			Graphics.Blit( source, destination, material );
 		}
 	}


### PR DESCRIPTION
This allows for more fine-tuned adjustment of global brightness of lights.  Could potentially user wider range of values, though 0-2 should be sufficient for nearly all, if not all purposes.
